### PR TITLE
Add publish workflow for GHCR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish to GHCR
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/matt20013/abc_docker:latest


### PR DESCRIPTION
This PR adds a GitHub Actions workflow `.github/workflows/publish.yml` that builds and pushes the Docker image to the GitHub Container Registry (ghcr.io) whenever code is pushed to the master branch. The workflow checks out the repository, logs into GHCR using `secrets.GITHUB_TOKEN`, and pushes the image tagged as `latest`.

---
*PR created automatically by Jules for task [4731021735438193916](https://jules.google.com/task/4731021735438193916) started by @matt20013*