### PR TITLE
Refactor scripts to use absolute paths for Docker compatibility

### DIFF
--- a/scripts/create_pdf.sh
+++ b/scripts/create_pdf.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+ABC_DIR="/abcs"
+PDF_DIR="/pdfs"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 if [[ -z "$ABC_FILENAME" ]]; then
    echo "Empty ABC_FILENAME please set"
 fi
@@ -8,27 +13,27 @@ if [[ -z "$ABC_FONTS_PATH" ]]; then
    ABC_FONTS_PATH=/Library/Fonts
 fi
 
-if test -f ../abcs${ABC_FILENAME}.fmt; then
-    abcm2ps -O ../pdfs/${ABC_FILENAME}_raw.ps -F ../abcs${ABC_FILENAME}.fmt ../abcs/${ABC_FILENAME}.abc
+if test -f "$ABC_DIR/${ABC_FILENAME}.fmt"; then
+    abcm2ps -O "$PDF_DIR/${ABC_FILENAME}_raw.ps" -F "$ABC_DIR/${ABC_FILENAME}.fmt" "$ABC_DIR/${ABC_FILENAME}.abc"
 #else
 #    echo WARNING ${ABC_FILENAME}.fmt DOES NOT EXIST. Creating PS file WITHOUT format file
 #    ../abcm2ps/abcm2ps -O pdfs/${ABC_FILENAME}_raw.ps  abcs/${ABC_FILENAME}.abc   
 else
-    echo WARNING ../abcs/${ABC_FILENAME}.fmt DOES NOT EXIST. Using default.fmt
-    abcm2ps -O ../pdfs/${ABC_FILENAME}_raw.ps -F ../abcs/default.fmt ../abcs/${ABC_FILENAME}.abc
+    echo WARNING "$ABC_DIR/${ABC_FILENAME}.fmt" DOES NOT EXIST. Using default.fmt
+    abcm2ps -O "$PDF_DIR/${ABC_FILENAME}_raw.ps" -F "$ABC_DIR/default.fmt" "$ABC_DIR/${ABC_FILENAME}.abc"
 fi
 
 if [ $? -eq 0 ]
 then
-    echo ../pdfs${ABC_FILENAME}_raw.ps created successfully
+    echo "$PDF_DIR/${ABC_FILENAME}_raw.ps" created successfully
 else
-    echo FAILED to create ../pdfs/${ABC_FILENAME}_raw.ps
-    #exit 1
+    echo FAILED to create "$PDF_DIR/${ABC_FILENAME}_raw.ps"
+    exit 1
 fi
 
 #../abcm2ps/abcm2ps -O pdfs/${ABC_FILENAME}_raw.ps -F ${ABC_FILENAME}.fmt ${ABC_FILENAME}.abc
-tclsh abcmaddidx.tcl ../pdfs/${ABC_FILENAME}_raw.ps ../pdfs/${ABC_FILENAME}.ps
+tclsh "$SCRIPT_DIR/abcmaddidx.tcl" "$PDF_DIR/${ABC_FILENAME}_raw.ps" "$PDF_DIR/${ABC_FILENAME}.ps"
 #rm pdfs/${ABC_FILENAME}_raw.ps
-ps2pdf -sFONTPATH=${ABC_FONTS_PATH} ../pdfs/${ABC_FILENAME}.ps ../pdfs/${ABC_FILENAME}.pdf
+ps2pdf -sFONTPATH=${ABC_FONTS_PATH} "$PDF_DIR/${ABC_FILENAME}.ps" "$PDF_DIR/${ABC_FILENAME}.pdf"
 #rm pdfs/${ABC_FILENAME}.ps
 exit 0

--- a/scripts/generate_mp3.py
+++ b/scripts/generate_mp3.py
@@ -29,8 +29,8 @@ commands = []
 tunes = []
 tune = None
 
-midi_folder = "../midi/" + filename_no_ext
-mp3s_folder = "../mp3s/" + filename_no_ext
+midi_folder = "/midi/" + filename_no_ext
+mp3s_folder = "/mp3s/" + filename_no_ext
 
 Path(midi_folder).mkdir(parents=True, exist_ok=True)
 Path(mp3s_folder).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Refactored `scripts/create_pdf.sh` and `scripts/generate_mp3.py` to use absolute paths instead of relative paths, ensuring compatibility with Docker volume mounts.
- In `create_pdf.sh`:
  - Defined `ABC_DIR="/abcs"` and `PDF_DIR="/pdfs"`.
  - Resolved `SCRIPT_DIR` dynamically to locate `abcmaddidx.tcl`.
  - Replaced relative paths with these variables.
  - Fixed a missing slash bug in `../abcs${ABC_FILENAME}.fmt`.
  - Added `exit 1` if `abcm2ps` fails.
- In `generate_mp3.py`:
  - Updated `midi_folder` to `/midi/` + filename.
  - Updated `mp3s_folder` to `/mp3s/` + filename.
Verified changes with a test script using mocked tools and patched paths.

---
*PR created automatically by Jules for task [3092439935856569653](https://jules.google.com/task/3092439935856569653) started by @matt20013*