### PR TITLE
Update elgohr/Publish-Docker-Github-Action to v5

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: matt20013/abc-docker
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
Updated `.github/workflows/dockerhub.yml` to use `elgohr/Publish-Docker-Github-Action@v5` instead of `@master`. This fixes the deprecation warning and the Docker client version mismatch error reported in the logs.

---
*PR created automatically by Jules for task [13006765578595234730](https://jules.google.com/task/13006765578595234730) started by @matt20013*