### PR TITLE
Fix UnicodeEncodeError in Docker and CSV generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:18.04
+ENV PYTHONIOENCODING=UTF-8
 RUN apt update
 RUN apt-get install -y abcm2ps abcmidi timidity tclsh lame sox python3 nano ghostscript
 RUN cd "$(dirname $(which python3))" && ln -s idle3 idle \

--- a/scripts/generate_csv.py
+++ b/scripts/generate_csv.py
@@ -31,7 +31,7 @@ re_info_line = re.compile(info_line_pattern)
 #commands = ["abc2midi {filename}.abc -Q 150".format(filename=filename_no_ext)]
 tunes = []
 tune = None
-with open(input_path, "r") as f:
+with open(input_path, "r", encoding="utf-8") as f:
 
     lines = f.readlines()
 
@@ -58,7 +58,7 @@ with open(input_path, "r") as f:
 
     #keys = tunes[0].keys()
     keys = ["X","R","T","G","K","M","L","Q","E","I","C","S","Z","F","O","B","N","P","D","H","W","A"]
-    with open(output_path, 'w') as output_file:
+    with open(output_path, 'w', encoding="utf-8") as output_file:
         dict_writer = csv.DictWriter(output_file, keys)
         dict_writer.writeheader()
         dict_writer.writerows(tunes)


### PR DESCRIPTION
This PR addresses a `UnicodeEncodeError` that occurred in the GitHub Actions workflow due to the Docker container defaulting to ASCII encoding.

Changes:
1.  **`Dockerfile`**: Added `ENV PYTHONIOENCODING=UTF-8` to ensure Python uses UTF-8 for standard I/O, fixing the crash in `generate_mp3.py` when printing commands with non-ASCII characters (e.g., curly apostrophes).
2.  **`scripts/generate_csv.py`**: Explicitly added `encoding="utf-8"` to file open calls for both input and output files. This is a proactive fix to ensure consistent encoding handling across scripts.

Note: `scripts/generate_mp3.py` was checked and found to already have `encoding="utf-8"` for reading input files, so no changes were needed there beyond the environment variable fix in the Dockerfile.

---
*PR created automatically by Jules for task [11754273620885631435](https://jules.google.com/task/11754273620885631435) started by @matt20013*