### PR TITLE
Skip tune stubs in abc2wav pipeline

### DIFF
--- a/scripts/generate_mp3.py
+++ b/scripts/generate_mp3.py
@@ -18,6 +18,21 @@ args = parser.parse_args()
 input_path = args.input_path
 output_path = args.output_path
 
+def generate_commands(tune, input_path, midi_folder, mp3s_folder):
+    abc_path = input_path
+    midi_path = "{midi_folder}/{X}.mid".format(midi_folder=midi_folder,X=tune["X"])
+    raw_wav_path = "{mp3s_folder}/{X}.raw.wav".format(mp3s_folder=mp3s_folder,X=tune["X"])
+    wav_path = "{mp3s_folder}/{X}.wav".format(mp3s_folder=mp3s_folder,X=tune["X"])
+    mp3_path = "{mp3s_folder}/{X}-{tune_title}.mp3".format(mp3s_folder=mp3s_folder,X=str(int(tune["X"])).zfill(3),tune_title=tune["T"].replace(" ","_").replace("'","").replace(",","").replace("(","").replace(")","") )
+    abc_to_midi = "abc2midi {abc_path} {X} -o {midi_path} -Q 150".format(abc_path=abc_path, midi_path=midi_path,X=tune["X"])
+    mid_to_wave = "timidity {midi_path} -Ow -o {raw_wav_path}".format(midi_path=midi_path,raw_wav_path=raw_wav_path)
+    remove_silence = "sox {raw_wav_path} {wav_path} silence 1 0.1 1% -1 0.1 1%".format(raw_wav_path=raw_wav_path,wav_path=wav_path)
+    wav_to_mp3 = "lame {wav_path} -b 64 {mp3_path}".format(wav_path=wav_path,mp3_path=mp3_path)
+    remove_raw_wav = "rm {raw_wav_path}".format(raw_wav_path=raw_wav_path)
+    remove_wav = "rm {wav_path}".format(wav_path=wav_path)
+    remove_mid = "rm {midi_path}".format(midi_path=midi_path)
+    return [abc_to_midi, mid_to_wave,remove_silence,wav_to_mp3,remove_mid,remove_raw_wav,remove_wav]
+
 
 filename_no_ext = Path(input_path).stem
 
@@ -44,20 +59,9 @@ with open(input_path, "r", encoding="utf-8") as f:
         if re_info_line.match(line):
             if line.startswith("X:"):
                 if tune is not None:
-                    tunes.append(tune)
-                    abc_path = input_path
-                    midi_path = "{midi_folder}/{X}.mid".format(midi_folder=midi_folder,X=tune["X"]) 
-                    raw_wav_path = "{mp3s_folder}/{X}.raw.wav".format(mp3s_folder=mp3s_folder,X=tune["X"])
-                    wav_path = "{mp3s_folder}/{X}.wav".format(mp3s_folder=mp3s_folder,X=tune["X"])
-                    mp3_path = "{mp3s_folder}/{X}-{tune_title}.mp3".format(mp3s_folder=mp3s_folder,X=str(int(tune["X"])).zfill(3),tune_title=tune["T"].replace(" ","_").replace("'","").replace(",","").replace("(","").replace(")","") )
-                    abc_to_midi = "abc2midi {abc_path} {X} -o {midi_path} -Q 150".format(abc_path=abc_path, midi_path=midi_path,X=tune["X"])
-                    mid_to_wave = "timidity {midi_path} -Ow -o {raw_wav_path}".format(midi_path=midi_path,raw_wav_path=raw_wav_path)
-                    remove_silence = "sox {raw_wav_path} {wav_path} silence 1 0.1 1% -1 0.1 1%".format(raw_wav_path=raw_wav_path,wav_path=wav_path)
-                    wav_to_mp3 = "lame {wav_path} -b 64 {mp3_path}".format(wav_path=wav_path,mp3_path=mp3_path)
-                    remove_raw_wav = "rm {raw_wav_path}".format(raw_wav_path=raw_wav_path)
-                    remove_wav = "rm {wav_path}".format(wav_path=wav_path)
-                    remove_mid = "rm {midi_path}".format(midi_path=midi_path)
-                    commands.extend([abc_to_midi, mid_to_wave,remove_silence,wav_to_mp3,remove_mid,remove_raw_wav,remove_wav])
+                    if "K" in tune:
+                        tunes.append(tune)
+                        commands.extend(generate_commands(tune, input_path, midi_folder, mp3s_folder))
                 tune = {}
 
             arr = line.split(":")
@@ -65,6 +69,11 @@ with open(input_path, "r", encoding="utf-8") as f:
             value = arr[1].strip()
 
             tune[key] = value
+
+if tune is not None:
+    if "K" in tune:
+        tunes.append(tune)
+        commands.extend(generate_commands(tune, input_path, midi_folder, mp3s_folder))
 
 import subprocess
 


### PR DESCRIPTION
Modified `scripts/generate_mp3.py` to:
1. Skip tunes that do not have a Key (`K`) field, as these are considered stubs and cause `abc2midi` to fail.
2. Fix a bug where the last tune in the file was ignored.
3. Refactor command generation into a `generate_commands` function to reduce code duplication.

---
*PR created automatically by Jules for task [17115690962414673118](https://jules.google.com/task/17115690962414673118) started by @matt20013*