### PR TITLE
Quote paths in CLI commands

### DIFF
--- a/scripts/convert_jpg_to_eps.sh
+++ b/scripts/convert_jpg_to_eps.sh
@@ -1,4 +1,4 @@
 for i in abcs/*.jpg; do # Whitespace-safe but not recursive.
-    export JPG_FILENAME=$(echo $i | cut -f 1 -d '.')
-    convert ${JPG_FILENAME}.jpg ${JPG_FILENAME}.eps 
+    export JPG_FILENAME="$(echo "$i" | cut -f 1 -d '.')"
+    convert "${JPG_FILENAME}.jpg" "${JPG_FILENAME}.eps"
 done

--- a/scripts/create_all_pdfs.sh
+++ b/scripts/create_all_pdfs.sh
@@ -8,7 +8,7 @@
 #done
 
 for i in ../abcs/*.abc; do # Whitespace-safe but not recursive.
-    export ABC_FILENAME=$(echo $i | cut -f 1 -d '.')
-    echo $ABC_FILENAME
+    export ABC_FILENAME="$(echo "$i" | cut -f 1 -d '.')"
+    echo "$ABC_FILENAME"
     ./create_pdf.sh
 done

--- a/scripts/generate_all_csvs.sh
+++ b/scripts/generate_all_csvs.sh
@@ -9,10 +9,10 @@
 #done
 
 for i in abcs/*.abc; do # Whitespace-safe but not recursive.
-    echo $i
-    export ABC_PATH=$i
+    echo "$i"
+    export ABC_PATH="$i"
     export ABC_FILE="${i##*/}"
     export ABC_FILENAME="${ABC_FILE%.*}"
-    echo $ABC_FILENAME
-    python generate_csv.py abcs/${ABC_FILENAME}.abc csvs/${ABC_FILENAME}.csv
+    echo "$ABC_FILENAME"
+    python generate_csv.py "abcs/${ABC_FILENAME}.abc" "csvs/${ABC_FILENAME}.csv"
 done

--- a/scripts/generate_all_mp3s.sh
+++ b/scripts/generate_all_mp3s.sh
@@ -9,10 +9,10 @@
 #done
 
 for i in abcs/*.abc; do # Whitespace-safe but not recursive.
-    echo $i
-    export ABC_PATH=$i
+    echo "$i"
+    export ABC_PATH="$i"
     export ABC_FILE="${i##*/}"
     export ABC_FILENAME="${ABC_FILE%.*}"
-    echo $ABC_FILENAME
-    python generate_mp3.py ../abcs/${ABC_FILENAME}.abc ../mp3s/
+    echo "$ABC_FILENAME"
+    python generate_mp3.py "../abcs/${ABC_FILENAME}.abc" "../mp3s/"
 done

--- a/scripts/generate_mp3.py
+++ b/scripts/generate_mp3.py
@@ -1,6 +1,8 @@
 import csv
 import re
 import argparse
+import shlex
+import subprocess
 from pathlib import Path
 
 parser = argparse.ArgumentParser(description='Generate CSV file of ABC notation metadata')
@@ -24,13 +26,15 @@ def generate_commands(tune, input_path, midi_folder, mp3s_folder):
     raw_wav_path = "{mp3s_folder}/{X}.raw.wav".format(mp3s_folder=mp3s_folder,X=tune["X"])
     wav_path = "{mp3s_folder}/{X}.wav".format(mp3s_folder=mp3s_folder,X=tune["X"])
     mp3_path = "{mp3s_folder}/{X}-{tune_title}.mp3".format(mp3s_folder=mp3s_folder,X=str(int(tune["X"])).zfill(3),tune_title=tune["T"].replace(" ","_").replace("'","").replace(",","").replace("(","").replace(")","") )
-    abc_to_midi = "abc2midi {abc_path} {X} -o {midi_path} -Q 150".format(abc_path=abc_path, midi_path=midi_path,X=tune["X"])
-    mid_to_wave = "timidity {midi_path} -Ow -o {raw_wav_path}".format(midi_path=midi_path,raw_wav_path=raw_wav_path)
-    remove_silence = "sox {raw_wav_path} {wav_path} silence 1 0.1 1% -1 0.1 1%".format(raw_wav_path=raw_wav_path,wav_path=wav_path)
-    wav_to_mp3 = "lame {wav_path} -b 64 {mp3_path}".format(wav_path=wav_path,mp3_path=mp3_path)
-    remove_raw_wav = "rm {raw_wav_path}".format(raw_wav_path=raw_wav_path)
-    remove_wav = "rm {wav_path}".format(wav_path=wav_path)
-    remove_mid = "rm {midi_path}".format(midi_path=midi_path)
+
+    abc_to_midi = ["abc2midi", abc_path, tune["X"], "-o", midi_path, "-Q", "150"]
+    mid_to_wave = ["timidity", midi_path, "-Ow", "-o", raw_wav_path]
+    remove_silence = ["sox", raw_wav_path, wav_path, "silence", "1", "0.1", "1%", "-1", "0.1", "1%"]
+    wav_to_mp3 = ["lame", wav_path, "-b", "64", mp3_path]
+    remove_raw_wav = ["rm", raw_wav_path]
+    remove_wav = ["rm", wav_path]
+    remove_mid = ["rm", midi_path]
+
     return [abc_to_midi, mid_to_wave,remove_silence,wav_to_mp3,remove_mid,remove_raw_wav,remove_wav]
 
 
@@ -75,12 +79,10 @@ if tune is not None:
         tunes.append(tune)
         commands.extend(generate_commands(tune, input_path, midi_folder, mp3s_folder))
 
-import subprocess
-
 for command in commands:
 
-    print(command)
-    out = subprocess.Popen(command.split(" "), 
+    print(' '.join(shlex.quote(arg) for arg in command))
+    out = subprocess.Popen(command,
            stdout=subprocess.PIPE, 
            stderr=subprocess.STDOUT)
 


### PR DESCRIPTION
Updated shell scripts and generate_mp3.py to correctly quote file paths in command execution, handling filenames with spaces properly.

- Modified `scripts/generate_mp3.py` to use `subprocess.Popen` with argument lists instead of splitting strings, ensuring safe handling of paths with spaces. Added `shlex` quoting for logging.
- Updated `scripts/generate_all_mp3s.sh`, `scripts/generate_all_csvs.sh`, `scripts/create_all_pdfs.sh`, and `scripts/convert_jpg_to_eps.sh` to quote variable expansions and command arguments.

---
*PR created automatically by Jules for task [7925027964799445187](https://jules.google.com/task/7925027964799445187) started by @matt20013*