### PR TITLE
Fix UnicodeEncodeError in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:18.04
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 ENV PYTHONIOENCODING=UTF-8
 RUN apt update
 RUN apt-get install -y abcm2ps abcmidi timidity tclsh lame sox python3 nano ghostscript


### PR DESCRIPTION
Fixes `UnicodeEncodeError` when generating MP3s for filenames with special characters (e.g., smart apostrophes) by setting the Docker container locale to `C.UTF-8`.

---
*PR created automatically by Jules for task [15849196601615560996](https://jules.google.com/task/15849196601615560996) started by @matt20013*