### PR TITLE
Add FORCE_CREATION option to create_pdf.sh

### DIFF
--- a/scripts/create_pdf.sh
+++ b/scripts/create_pdf.sh
@@ -27,8 +27,11 @@ else
     abcm2ps -O "$PDF_DIR/${ABC_FILENAME}_raw.ps" -F "$ABC_DIR/default.fmt" "$ABC_DIR/${ABC_FILENAME}.abc"
 fi
 
-if [ $? -eq 0 ] && [ -s "$PDF_DIR/${ABC_FILENAME}_raw.ps" ]; then
+RET_CODE=$?
+if [ $RET_CODE -eq 0 ] && [ -s "$PDF_DIR/${ABC_FILENAME}_raw.ps" ]; then
     echo "$PDF_DIR/${ABC_FILENAME}_raw.ps" created successfully
+elif [ -n "$FORCE_CREATION" ] && [ "$FORCE_CREATION" != "0" ] && [ -s "$PDF_DIR/${ABC_FILENAME}_raw.ps" ]; then
+    echo "WARNING: abcm2ps exited with code $RET_CODE but FORCE_CREATION is set. Proceeding..."
 else
     echo FAILED to create "$PDF_DIR/${ABC_FILENAME}_raw.ps"
     exit 1


### PR DESCRIPTION
Added support for `FORCE_CREATION` environment variable in `scripts/create_pdf.sh`. If set to a non-zero value, the script will proceed with PDF generation even if `abcm2ps` exits with a non-zero status code, provided the raw PostScript file was created. This allows for processing of files that may trigger warnings or minor errors in `abcm2ps` but still produce valid output.

---
*PR created automatically by Jules for task [10668244469972438314](https://jules.google.com/task/10668244469972438314) started by @matt20013*