### PR TITLE
Add script to clean ABC files

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ There are helper scripts to process all ABC files in the `/abcs` directory.
   ./generate_all_csvs.sh
   ```
 
+### Clean up ABC files
+Fixes Windows line endings (CRLF) and trailing spaces that cause `abc2midi` to crash.
+`docker run -it -v ${PWD}/abcs:/abcs/ abc ./clean_abc.sh ../abcs/tunes.abc`
+
 ## CI / GitHub Actions
 
 You can use this Docker image in your CI/CD pipeline to automatically generate media files from your ABC files.

--- a/scripts/clean_abc.sh
+++ b/scripts/clean_abc.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [ -z "$1" ]; then
+    echo "Usage: ./clean_abc.sh <path_to_abc_file>"; exit 1
+fi
+FILE="$1"
+echo "Cleaning up $FILE..."
+sed -i 's/\r$//' "$FILE"
+sed -i 's/[[:space:]]*$//' "$FILE"
+echo "Cleanup complete!"


### PR DESCRIPTION
Added scripts/clean_abc.sh to remove CRLF and trailing spaces from ABC files. Updated README.md with usage instructions.

---
*PR created automatically by Jules for task [7554401562297215401](https://jules.google.com/task/7554401562297215401) started by @matt20013*