### PR TITLE
Update Dockerfile to use latest abc2midi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,16 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV PYTHONIOENCODING=UTF-8
 RUN apt update
-RUN apt-get install -y abcm2ps timidity tclsh lame sox python3 nano ghostscript imagemagick build-essential unzip wget
+RUN apt-get install -y abcm2ps timidity tclsh lame sox python3 nano ghostscript imagemagick build-essential git
 
-# Download and install latest abcMIDI
-RUN wget https://ifdo.ca/~seymour/runabc/abcMIDI-2026.02.18.zip && \
-    unzip abcMIDI-2026.02.18.zip && \
+# Download and install latest abcMIDI from GitHub
+RUN git clone https://github.com/sshlien/abcmidi.git && \
     cd abcmidi && \
     ./configure && \
     make && \
     make install && \
     cd .. && \
-    rm -rf abcmidi abcMIDI-2026.02.18.zip
+    rm -rf abcmidi
 
 RUN cd "$(dirname $(which python3))" && ln -s idle3 idle \
     && ln -s pydoc3 pydoc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,18 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV PYTHONIOENCODING=UTF-8
 RUN apt update
-RUN apt-get install -y abcm2ps abcmidi timidity tclsh lame sox python3 nano ghostscript imagemagick
+RUN apt-get install -y abcm2ps timidity tclsh lame sox python3 nano ghostscript imagemagick build-essential unzip wget
+
+# Download and install latest abcMIDI
+RUN wget https://ifdo.ca/~seymour/runabc/abcMIDI-2026.02.18.zip && \
+    unzip abcMIDI-2026.02.18.zip && \
+    cd abcmidi && \
+    ./configure && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf abcmidi abcMIDI-2026.02.18.zip
+
 RUN cd "$(dirname $(which python3))" && ln -s idle3 idle \
     && ln -s pydoc3 pydoc \
     && ln -s python3 python \


### PR DESCRIPTION
Replaced the apt package installation of `abcmidi` with a source build of the latest version (2026.02.18). This ensures we are using the most up-to-date features and bug fixes. Added build dependencies `build-essential`, `unzip`, and `wget`.

---
*PR created automatically by Jules for task [7181713702726825059](https://jules.google.com/task/7181713702726825059) started by @matt20013*