### PR TITLE
Fix Docker build hang in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:22.04
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV PYTHONIOENCODING=UTF-8
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update
 RUN apt-get install -y abcm2ps timidity tclsh lame sox python3 nano ghostscript imagemagick build-essential git
 


### PR DESCRIPTION
The Docker build was hanging in CI because `apt-get install` was prompting for timezone configuration (via `tzdata`).
I added `ARG DEBIAN_FRONTEND=noninteractive` to the Dockerfile to suppress these interactive prompts, allowing the build to proceed automatically using default values. This is standard practice for Debian-based Docker builds.
Verified the syntax of the Dockerfile change.

---
*PR created automatically by Jules for task [8370041751575938730](https://jules.google.com/task/8370041751575938730) started by @matt20013*