### PR TITLE
Fix exec format error in convert_jpg_to_eps.sh

### DIFF
--- a/scripts/convert_jpg_to_eps.sh
+++ b/scripts/convert_jpg_to_eps.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 for i in ../abcs/*.jpg; do # Whitespace-safe but not recursive.
     echo "$i"
     export JPG_FILENAME="${i%.*}"


### PR DESCRIPTION
Added `#!/bin/bash` to `scripts/convert_jpg_to_eps.sh` to resolve `exec format error`. Verified by executing the script and confirming the error is no longer present.

---
*PR created automatically by Jules for task [10252175275039064](https://jules.google.com/task/10252175275039064) started by @matt20013*