### PR TITLE
Fix MP3 generation skipping the last tune in ABC file

### DIFF
--- a/scripts/generate_mp3.py
+++ b/scripts/generate_mp3.py
@@ -3,6 +3,7 @@ import csv
 import re
 import argparse
 from pathlib import Path
+import subprocess
 
 parser = argparse.ArgumentParser(description='Generate CSV file of ABC notation metadata')
 parser.add_argument('input_path',
@@ -36,6 +37,23 @@ mp3s_folder = str(Path(output_path).joinpath(filename_no_ext))
 Path(midi_folder).mkdir(parents=True, exist_ok=True)
 Path(mp3s_folder).mkdir(parents=True, exist_ok=True)
 
+def process_tune(tune):
+    if tune is not None:
+        tunes.append(tune)
+        abc_path = input_path
+        midi_path = "{midi_folder}/{X}.mid".format(midi_folder=midi_folder,X=tune["X"])
+        raw_wav_path = "{mp3s_folder}/{X}.raw.wav".format(mp3s_folder=mp3s_folder,X=tune["X"])
+        wav_path = "{mp3s_folder}/{X}.wav".format(mp3s_folder=mp3s_folder,X=tune["X"])
+        mp3_path = "{mp3s_folder}/{X}-{tune_title}.mp3".format(mp3s_folder=mp3s_folder,X=str(int(tune["X"])).zfill(3),tune_title=tune["T"].replace(" ","_").replace("'","").replace(",","").replace("(","").replace(")","") )
+        abc_to_midi = "abc2midi {abc_path} {X} -o {midi_path} -Q 150".format(abc_path=abc_path, midi_path=midi_path,X=tune["X"])
+        mid_to_wave = "timidity {midi_path} -Ow -o {raw_wav_path}".format(midi_path=midi_path,raw_wav_path=raw_wav_path)
+        remove_silence = "sox {raw_wav_path} {wav_path} silence 1 0.1 1% -1 0.1 1%".format(raw_wav_path=raw_wav_path,wav_path=wav_path)
+        wav_to_mp3 = "lame {wav_path} -b 64 {mp3_path}".format(wav_path=wav_path,mp3_path=mp3_path)
+        remove_raw_wav = "rm {raw_wav_path}".format(raw_wav_path=raw_wav_path)
+        remove_wav = "rm {wav_path}".format(wav_path=wav_path)
+        remove_mid = "rm {midi_path}".format(midi_path=midi_path)
+        commands.extend([abc_to_midi, mid_to_wave,remove_silence,wav_to_mp3,remove_mid,remove_raw_wav,remove_wav])
+
 with open(input_path, "r", encoding="utf-8") as f:
 
     lines = f.readlines()
@@ -44,21 +62,7 @@ with open(input_path, "r", encoding="utf-8") as f:
 
         if re_info_line.match(line):
             if line.startswith("X:"):
-                if tune is not None:
-                    tunes.append(tune)
-                    abc_path = input_path
-                    midi_path = "{midi_folder}/{X}.mid".format(midi_folder=midi_folder,X=tune["X"]) 
-                    raw_wav_path = "{mp3s_folder}/{X}.raw.wav".format(mp3s_folder=mp3s_folder,X=tune["X"])
-                    wav_path = "{mp3s_folder}/{X}.wav".format(mp3s_folder=mp3s_folder,X=tune["X"])
-                    mp3_path = "{mp3s_folder}/{X}-{tune_title}.mp3".format(mp3s_folder=mp3s_folder,X=str(int(tune["X"])).zfill(3),tune_title=tune["T"].replace(" ","_").replace("'","").replace(",","").replace("(","").replace(")","") )
-                    abc_to_midi = "abc2midi {abc_path} {X} -o {midi_path} -Q 150".format(abc_path=abc_path, midi_path=midi_path,X=tune["X"])
-                    mid_to_wave = "timidity {midi_path} -Ow -o {raw_wav_path}".format(midi_path=midi_path,raw_wav_path=raw_wav_path)
-                    remove_silence = "sox {raw_wav_path} {wav_path} silence 1 0.1 1% -1 0.1 1%".format(raw_wav_path=raw_wav_path,wav_path=wav_path)
-                    wav_to_mp3 = "lame {wav_path} -b 64 {mp3_path}".format(wav_path=wav_path,mp3_path=mp3_path)
-                    remove_raw_wav = "rm {raw_wav_path}".format(raw_wav_path=raw_wav_path)
-                    remove_wav = "rm {wav_path}".format(wav_path=wav_path)
-                    remove_mid = "rm {midi_path}".format(midi_path=midi_path)
-                    commands.extend([abc_to_midi, mid_to_wave,remove_silence,wav_to_mp3,remove_mid,remove_raw_wav,remove_wav])
+                process_tune(tune)
                 tune = {}
 
             arr = line.split(":")
@@ -67,7 +71,8 @@ with open(input_path, "r", encoding="utf-8") as f:
 
             tune[key] = value
 
-import subprocess
+    process_tune(tune)
+
 
 for command in commands:
 


### PR DESCRIPTION
The `scripts/generate_mp3.py` script had a logic error where it buffered tune data and only processed it when encountering the *next* tune's `X:` header. This meant the final tune in any ABC file (or the only tune in a single-tune file) was never processed, resulting in empty output directories.

This change:
1.  Extracts the MP3 command generation and cleanup logic into a helper function `process_tune(tune)`.
2.  Calls `process_tune(tune)` inside the main loop when a new tune starts (processing the *previous* tune).
3.  Calls `process_tune(tune)` **after** the loop finishes to process the final accumulated tune data.
4.  Moves the `subprocess` import to the top of the file for better style and scoping.

Verified with a reproduction script that confirmed 0 commands were generated before the fix and 7 commands (generation + cleanup) were generated after the fix for `test_tune.abc`.

---
*PR created automatically by Jules for task [7560230280825686286](https://jules.google.com/task/7560230280825686286) started by @matt20013*