### PR TITLE
Merge master into pr-23 and fix conflicts

### DIFF
--- a/scripts/generate_mp3.py
+++ b/scripts/generate_mp3.py
@@ -5,7 +5,6 @@ import argparse
 import sys
 import subprocess
 from pathlib import Path
-import subprocess
 
 # Ensure immediate output flushing
 sys.stdout.reconfigure(line_buffering=True)

--- a/scripts/makesets.py
+++ b/scripts/makesets.py
@@ -14,10 +14,10 @@ import string,re,sys
 
 def main():
     "Script to create sets from Paul Hardy's Session Tunebook."
-    inabcprifilename = "C:\Users\Public\Documents\Music\ABC\PGH_Tunebooks\PGH_Session_Tunebook\pgh_session_tunebook.abc"
-    inabcannfilename = "C:\Users\Public\Documents\Music\ABC\PGH_Tunebooks\PGH_Annex_Tunebook\pgh_annex_tunebook.abc"
-    indefnfilename = "C:\Users\Public\Documents\Music\ABC\PGH_Tunebooks\PGH_Sets_Tunebook\pgh_sets_tunebook.abct"
-    outabcfilename = "C:\Users\Public\Documents\Music\ABC\PGH_Tunebooks\PGH_Sets_Tunebook\pgh_sets_tunebook.abc"
+    inabcprifilename = r"C:\Users\Public\Documents\Music\ABC\PGH_Tunebooks\PGH_Session_Tunebook\pgh_session_tunebook.abc"
+    inabcannfilename = r"C:\Users\Public\Documents\Music\ABC\PGH_Tunebooks\PGH_Annex_Tunebook\pgh_annex_tunebook.abc"
+    indefnfilename = r"C:\Users\Public\Documents\Music\ABC\PGH_Tunebooks\PGH_Sets_Tunebook\pgh_sets_tunebook.abct"
+    outabcfilename = r"C:\Users\Public\Documents\Music\ABC\PGH_Tunebooks\PGH_Sets_Tunebook\pgh_sets_tunebook.abc"
     try:
         indefnfile = open(indefnfilename, 'r')  
     except IOError:


### PR DESCRIPTION
Resolved merge conflicts between `pr-23` and `master`.
The resolution heavily favors `pr-23` (`HEAD`) as it contains significant structural changes (workflow files, script enhancements) that supersede `master`.
Specifically:
- Accepted `pr-23` version of `.github/workflows/test_action.yml`, `Dockerfile`, `action.yml`, `scripts/action_entrypoint.sh`, and `scripts/generate_mp3.py`.
- Accepted deletion of `.gitignore` by `pr-23`.
- Additionally, fixed a `SyntaxError` in `scripts/makesets.py` (invalid escape sequence in Windows path) and cleaned up duplicate imports in `scripts/generate_mp3.py`.
- Verified `scripts/generate_mp3.py` executes without syntax errors (though execution fails due to missing dependencies in environment, argument parsing works).

---
*PR created automatically by Jules for task [16882242889325759692](https://jules.google.com/task/16882242889325759692) started by @matt20013*