### PR TITLE
Fix duplicate keys in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,3 @@
-name: 'ABC Tunes Compiler'
-description: 'Compiles ABC notation files into high-quality PDFs and MP3s.'
-author: 'Matt'
-inputs:
-  abc_dir:
-    description: 'The folder containing your .abc files'
-    required: false
-    default: 'abcs'
-  file_name:
-    description: 'The specific ABC file to process (without extension)'
-    required: false
 name: 'ABC Music Build'
 description: 'Builds PDFs, MP3s, and CSVs from ABC files using abc-docker tools'
 author: 'Matt'
@@ -17,6 +6,9 @@ inputs:
     description: 'Directory containing ABC files (relative to repository root)'
     required: false
     default: 'abcs'
+  file_name:
+    description: 'The specific ABC file to process (without extension)'
+    required: false
   pdf_dir:
     description: 'Directory for output PDFs (relative to repository root)'
     required: false


### PR DESCRIPTION
The `action.yml` file contained duplicate definitions for `name`, `description`, `author`, and `inputs`, causing a parsing error. This change consolidates the definitions into a single valid YAML structure, preserving all input parameters required for both single-file and batch processing modes.

---
*PR created automatically by Jules for task [16034113349535854184](https://jules.google.com/task/16034113349535854184) started by @matt20013*