### PR TITLE
Fix action release publishing by moving docker build to release-please workflow

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -3,8 +3,6 @@ name: Build and Publish Docker Image
 on:
   push:
     branches: [ 'master' ]
-  release:
-    types: [ published ]
 
 jobs:
   build-and-push-image:
@@ -28,12 +26,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/matt20013/abc_docker
           tags: |
             type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,47 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           release-type: simple
+
+  build-release:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/matt20013/abc_docker
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-please.outputs.tag_name }}
+            type=semver,pattern={{major}},value=${{ needs.release-please.outputs.tag_name }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR fixes the issue where the Docker image for the action was not being published upon release.

The problem was that `release-please` creates GitHub Releases using the default `GITHUB_TOKEN`. GitHub Actions prevents workflows from being triggered by events created by the `GITHUB_TOKEN` to avoid infinite loops. As a result, the `on: release` trigger in `publish-image.yml` was never firing, and the versioned Docker image required by `action.yml` (e.g., `v1.0.0`) was never pushed.

The fix involves:
1.  Adding a dependent `build-release` job directly to `.github/workflows/release-please.yml`. This job runs conditionally when a release is created and uses the tag name output from `release-please` to version the Docker image.
2.  Removing the broken `release` trigger from `.github/workflows/publish-image.yml`, leaving it to handle only `push` to `master` builds.
3.  Ensuring the image name is consistently set to `ghcr.io/matt20013/abc_docker`.

---
*PR created automatically by Jules for task [18344221327923082421](https://jules.google.com/task/18344221327923082421) started by @matt20013*