### PR TITLE
Update major and minor git tags on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,8 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      major: ${{ steps.release.outputs.major }}
+      minor: ${{ steps.release.outputs.minor }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -57,3 +59,20 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  update-tags:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update major and minor tags
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git tag -fa v${{ needs.release-please.outputs.major }} -m "Update major version tag"
+          git tag -fa v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }} -m "Update minor version tag"
+          git push origin v${{ needs.release-please.outputs.major }} --force
+          git push origin v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }} --force


### PR DESCRIPTION
Updated `.github/workflows/release-please.yml` to output major and minor versions from the `release-please` job and added a new `update-tags` job to force update the corresponding git tags.

---
*PR created automatically by Jules for task [14219236001610729369](https://jules.google.com/task/14219236001610729369) started by @matt20013*