### PR TITLE
Fix output directory creation and path handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,12 +19,18 @@ runs:
       run: docker pull ghcr.io/matt20013/abc_docker:${{ github.action_ref || 'latest' }}
       shell: bash
 
+    - name: Create Output Directories
+      run: |
+        mkdir -p "${{ github.workspace }}/pdfs"
+        mkdir -p "${{ github.workspace }}/mp3s"
+      shell: bash
+
     - name: Run PDF Generation
       run: |
         docker run --rm \
-        -v ${{ github.workspace }}/${{ inputs.abc_dir }}:/abcs/ \
-        -v ${{ github.workspace }}/pdfs:/pdfs/ \
-        --env ABC_FILENAME=${{ inputs.file_name }} \
+        -v "${{ github.workspace }}/${{ inputs.abc_dir }}":/abcs/ \
+        -v "${{ github.workspace }}/pdfs":/pdfs/ \
+        --env ABC_FILENAME="${{ inputs.file_name }}" \
         --env GIT_HASH=${GITHUB_SHA::7} \
         ghcr.io/matt20013/abc_docker:${{ github.action_ref || 'latest' }} /scripts/create_pdf.sh
       shell: bash
@@ -32,7 +38,7 @@ runs:
     - name: Run MP3 Generation
       run: |
         docker run --rm \
-        -v ${{ github.workspace }}/${{ inputs.abc_dir }}:/abcs/ \
-        -v ${{ github.workspace }}/mp3s:/mp3s/ \
-        ghcr.io/matt20013/abc_docker:${{ github.action_ref || 'latest' }} python3 /scripts/generate_mp3.py /abcs/${{ inputs.file_name }}.abc /mp3s
+        -v "${{ github.workspace }}/${{ inputs.abc_dir }}":/abcs/ \
+        -v "${{ github.workspace }}/mp3s":/mp3s/ \
+        ghcr.io/matt20013/abc_docker:${{ github.action_ref || 'latest' }} python3 /scripts/generate_mp3.py "/abcs/${{ inputs.file_name }}.abc" /mp3s
       shell: bash

--- a/scripts/create_pdf.sh
+++ b/scripts/create_pdf.sh
@@ -32,6 +32,9 @@ if [[ -z "$ABC_FONTS_PATH" ]]; then
    ABC_FONTS_PATH=/Library/Fonts
 fi
 
+# Ensure output directory exists (for subdirectories in ABC_FILENAME)
+mkdir -p "$(dirname "$PDF_DIR/${ABC_FILENAME}_raw.ps")"
+
 if test -f "$ABC_DIR/${ABC_FILENAME}.fmt"; then
     abcm2ps -O "$PDF_DIR/${ABC_FILENAME}_raw.ps" -F "$ABC_DIR/${ABC_FILENAME}.fmt" "$ABC_DIR/${ABC_FILENAME}.abc"
 elif test -f "$ABC_DIR/default.fmt"; then


### PR DESCRIPTION
This PR addresses an issue where generated files were not being written to the expected output directories, likely due to permission issues (Docker creating root-owned directories) or missing directory structures when using subdirectories in filenames.

Changes:
- Modified `action.yml` to explicitly create `pdfs` and `mp3s` directories on the host before running the Docker container. This ensures they are owned by the runner user.
- Updated `action.yml` to quote volume paths and environment variables to correctly handle paths with spaces.
- Updated `scripts/create_pdf.sh` to create the parent directory of the output file if it doesn't exist, preventing failures when `file_name` contains subdirectories.


---
*PR created automatically by Jules for task [1246347584500744060](https://jules.google.com/task/1246347584500744060) started by @matt20013*