### PR TITLE
feat: Add auto-commit functionality to abc_docker action

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           abc_dir: 'test_data/abcs'
           file_name: 'test_tune'
+          auto_commit: 'false'
       - name: Verify Output (Single File)
         run: |
           ls -R test_data
@@ -28,6 +29,7 @@ jobs:
           file_name: 'test_tune'
           pdf_dir: 'my_pdfs'
           mp3_dir: 'my_mp3s'
+          auto_commit: 'false'
       - name: Verify Output (Custom Outputs)
         run: |
           ls -R my_pdfs

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'The output folder for MP3 files'
     required: false
     default: 'mp3s'
+  auto_commit:
+    description: 'Whether to automatically commit the generated files back to the repo'
+    required: false
+    default: 'true'
 
 runs:
   using: "composite"
@@ -50,3 +54,10 @@ runs:
         -v "${{ github.workspace }}/${{ inputs.mp3_dir }}":/mp3s/ \
         ghcr.io/matt20013/abc_docker:${{ github.action_ref || 'latest' }} python3 /scripts/generate_mp3.py "/abcs/${{ inputs.file_name }}.abc" /mp3s
       shell: bash
+
+    - name: Commit Generated Media Back to Repo
+      if: ${{ inputs.auto_commit == 'true' }}
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "chore: update compiled PDFs and MP3s [skip ci]"
+        file_pattern: '${{ inputs.pdf_dir }} ${{ inputs.mp3_dir }}'


### PR DESCRIPTION
Added `auto_commit` input (default: true) to `action.yml` and a conditional step using `stefanzweifel/git-auto-commit-action` to commit generated PDFs and MP3s back to the repository. Updated `.github/workflows/test_action.yml` to disable auto-commit during tests.

---
*PR created automatically by Jules for task [1917864842758529428](https://jules.google.com/task/1917864842758529428) started by @matt20013*