### PR TITLE
fix: restore Petaluma font configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ RUN cd "$(dirname $(which python3))" && ln -s idle3 idle \
 COPY dependencies/*.sf2 /usr/share/sound/soundfonts/
 COPY dependencies/*.otf /root/.fonts/
 COPY scripts/ /scripts/
-RUN chmod +x /scripts/*.sh
+RUN chmod +x /scripts/*.sh && chmod 644 /scripts/default.fmt
 WORKDIR /scripts
 ENV ABC_FONTS_PATH=/root/.fonts

--- a/scripts/default.fmt
+++ b/scripts/default.fmt
@@ -1,2 +1,75 @@
-% Default format file
-landscape
+
+footer "$P0	$F 	$P1"
+
+dateformat "\%d \%b, \%Y"
+
+% page definition for A4
+   pageheight 29.7cm
+   pagewidth 21cm
+
+% page definition for US Letter
+%   pageheight 11in
+%   pagewidth 8.5in
+
+   topmargin 0.8cm
+   leftmargin 1.1cm
+   rightmargin 1.1cm
+   botmargin 1.2cm
+
+% squash things a bit
+   scale 0.95
+   staffwidth 18.8cm
+   staffsep   36
+   maxshrink  0.65
+   lineskipfac 1.1
+   parskipfac 0.4
+   textspace 0.2cm
+   topspace 0.1cm
+   titlespace 0.1cm
+   infospace 0.2cm
+   stretchlast 1
+
+% set up title for each tune
+   titleformat S-1 P-1 Q-1 T0 C1 O1 T0
+%   printtempo 0
+
+%  set fonts
+   titlefont      MarkerFelt-Wide 16
+   subtitlefont   Courier-Bold 11
+   composerfont   Courier 11
+   gchordfont     Courier-Bold 14
+   textfont       Courier 10
+   wordsfont      Courier 10
+   headerfont     Courier 12
+   footerfont     Courier 12
+   historyfont    Courier 10
+   infofont       Courier 11
+   tempofont      Courier 10
+   partsfont      Courier 11
+   repeatfont     Courier 10
+   tempofont      Courier 12
+   annotationfont Courier 10
+   measurefont    Courier 10
+   measurefont    Courier 10
+   setfont-1      Courier 10
+   setfont-2      Courier 10
+   setfont-3      Courier 10
+   setfont-4      Courier 10
+   voicefont      Courier 10
+   vocalfont      Courier 10
+   musicfont Petaluma
+
+% options for layout
+   partsbox       1
+
+% Use Verdana instead of Helvetica and PalatinoLinotype instead of Times.
+
+beginps
+/fontredef{
+findfont dup length
+dict begin
+{1 index/FID ne{def}{pop pop}ifelse}forall
+currentdict
+end
+definefont pop}!
+endps


### PR DESCRIPTION
This PR restores the `scripts/default.fmt` file content which was apparently overwritten with a minimal version. The restored version correctly references the Petaluma font and sets up other layout and font preferences used in the project. Additionally, the Dockerfile is updated to ensure the format file has correct read permissions.

---
*PR created automatically by Jules for task [847110796616442383](https://jules.google.com/task/847110796616442383) started by @matt20013*