### PR TITLE
🧪 Add Unit Test for get_env_var Function

### DIFF
--- a/tests/test_action_entrypoint.py
+++ b/tests/test_action_entrypoint.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import patch
+import os
+import sys
+
+# Add scripts directory to path so we can import action_entrypoint
+sys.path.append(os.path.join(os.path.dirname(__file__), '../scripts'))
+from action_entrypoint import get_env_var
+
+class TestGetEnvVar(unittest.TestCase):
+    @patch.dict(os.environ, {"INPUT_MY_VAR": "input_value", "MY_VAR": "env_value"})
+    def test_get_env_var_prioritizes_input(self):
+        # The function converts name to uppercase and prepends INPUT_
+        self.assertEqual(get_env_var("my_var"), "input_value")
+
+    @patch.dict(os.environ, {"MY_VAR": "env_value"}, clear=True)
+    def test_get_env_var_uses_env_if_no_input(self):
+        # If INPUT_MY_VAR is not set, it should check MY_VAR
+        self.assertEqual(get_env_var("MY_VAR"), "env_value")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_env_var_uses_default_if_none_set(self):
+        # If neither is set, return default
+        self.assertEqual(get_env_var("MY_VAR", "default_value"), "default_value")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_env_var_returns_none_if_no_default(self):
+        # Default is None
+        self.assertIsNone(get_env_var("MY_VAR"))
+
+    @patch.dict(os.environ, {"INPUT_MY_VAR": ""}, clear=True)
+    def test_get_env_var_handles_empty_string_input(self):
+        # Empty string should be returned if set
+        self.assertEqual(get_env_var("my_var"), "")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change adds a new unit test suite for the `get_env_var` function located in `scripts/action_entrypoint.py`. 

The tests cover the following scenarios:
1.  **Input Priority**: Verifies that `INPUT_<NAME_IN_UPPERCASE>` takes precedence over standard environment variables.
2.  **Env Fallback**: Verifies that the function falls back to the standard environment variable if the GitHub Actions input variant is not set.
3.  **Default Value**: Verifies that the provided default value is returned when neither the input nor the environment variable is present.
4.  **Implicit Default**: Verifies that `None` is returned when no default is provided and no variables are set.
5.  **Empty String Support**: Verifies that empty strings are correctly returned if set in the environment.

A new `tests/` directory was created to house the test suite. `__pycache__` files were excluded from the submission.

---
*PR created automatically by Jules for task [5181388449178543744](https://jules.google.com/task/5181388449178543744) started by @matt20013*